### PR TITLE
Enable scrolling after ImageView Zoom-In

### DIFF
--- a/FSImageViewer/FSImageView.m
+++ b/FSImageViewer/FSImageView.m
@@ -391,10 +391,12 @@
             if (offsetX < 0) offsetX = 0;
 
             self.scrollView.contentOffset = CGPointMake(offsetX, offsetY);
+            self.scrollView.scrollEnabled = YES;
         }
 
     } else {
         [self layoutScrollViewAnimated:YES];
+        self.scrollView.scrollEnabled = NO;
     }
 }
 


### PR DESCRIPTION
After zooming in via swipe, the image is not scrollable because the parent ScrollView has it's scrollEnabled property set to NO, this commit resolves this issue.
