### PR TITLE
Fixed UIPopoverPresentationController should have a non-nil sourceView or barButtonItem crash

### DIFF
--- a/FSImageViewer/FSImageViewerViewController.m
+++ b/FSImageViewer/FSImageViewerViewController.m
@@ -216,7 +216,9 @@
         NSAssert(currentImage.image, @"The image must be loaded to share.");
         if (currentImage.image) {
             UIActivityViewController *controller = [[UIActivityViewController alloc] initWithActivityItems:@[currentImage.image] applicationActivities:_applicationActivities];
-            controller.popoverPresentationController.barButtonItem = shareButton;
+            if(!controller.popoverPresentationController.barButtonItem){
+                controller.popoverPresentationController.barButtonItem = shareButton;
+            }
             [self presentViewController:controller animated:YES completion:nil];
         }
     }


### PR DESCRIPTION
Setting shareButton as the barButtonItem of UIActivityViewController's
popoverPresentationController to address the following crash:

Terminating app due to uncaught exception 'NSGenericException',
reason: 'UIPopoverPresentationController
(<_UIAlertControllerActionSheetRegularPresentationController:
0x7f89f85c53a0>) should have a non-nil sourceView or barButtonItem set
before the presentation occurs.'
