### PR TITLE
Improved modal detection

### DIFF
--- a/FSImageViewer/FSImageViewerViewController.h
+++ b/FSImageViewer/FSImageViewerViewController.h
@@ -76,7 +76,7 @@
 @property(assign, nonatomic, getter = isRotationEnabled) BOOL rotationEnabled;
 
 /// Override default modality detection - Default is NO
-@property(assign, nonatomic) BOOL shouldNotShowModally;
+@property(assign, nonatomic) BOOL ignoreModality;
 
 /// Override the background color when overlay is hidden - Default is black
 @property(strong, nonatomic) UIColor *backgroundColorHidden;

--- a/FSImageViewer/FSImageViewerViewController.h
+++ b/FSImageViewer/FSImageViewerViewController.h
@@ -75,6 +75,9 @@
 /// Override rotation of images - Default is YES
 @property(assign, nonatomic, getter = isRotationEnabled) BOOL rotationEnabled;
 
+/// Override default modality detection - Default is NO
+@property(assign, nonatomic) BOOL shouldNotShowModally;
+
 /// Override the background color when overlay is hidden - Default is black
 @property(strong, nonatomic) UIColor *backgroundColorHidden;
 

--- a/FSImageViewer/FSImageViewerViewController.h
+++ b/FSImageViewer/FSImageViewerViewController.h
@@ -75,9 +75,6 @@
 /// Override rotation of images - Default is YES
 @property(assign, nonatomic, getter = isRotationEnabled) BOOL rotationEnabled;
 
-/// Override default modality detection - Default is NO
-@property(assign, nonatomic) BOOL ignoreModality;
-
 /// Override the background color when overlay is hidden - Default is black
 @property(strong, nonatomic) UIColor *backgroundColorHidden;
 

--- a/FSImageViewer/FSImageViewerViewController.m
+++ b/FSImageViewer/FSImageViewerViewController.m
@@ -128,7 +128,7 @@
 
     shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(share:)];
     shareButton.enabled = NO;
-    if (!self.shouldNotShowModally && (self.presentingViewController && (self.modalPresentationStyle == UIModalPresentationFullScreen))) {
+    if (self.navigationController.viewControllers.count == 1) {
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:[self localizedStringForKey:@"done" withDefault:@"Done"] style:UIBarButtonItemStyleDone target:self action:@selector(done:)];
         self.navigationItem.rightBarButtonItem = doneButton;
         if (!_sharingDisabled) {

--- a/FSImageViewer/FSImageViewerViewController.m
+++ b/FSImageViewer/FSImageViewerViewController.m
@@ -128,7 +128,7 @@
 
     shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(share:)];
     shareButton.enabled = NO;
-    if (self.presentingViewController && (self.modalPresentationStyle == UIModalPresentationFullScreen)) {
+    if (!self.shouldNotShowModally || (self.presentingViewController && (self.modalPresentationStyle == UIModalPresentationFullScreen))) {
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:[self localizedStringForKey:@"done" withDefault:@"Done"] style:UIBarButtonItemStyleDone target:self action:@selector(done:)];
         self.navigationItem.rightBarButtonItem = doneButton;
         if (!_sharingDisabled) {

--- a/FSImageViewer/FSImageViewerViewController.m
+++ b/FSImageViewer/FSImageViewerViewController.m
@@ -128,7 +128,7 @@
 
     shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(share:)];
     shareButton.enabled = NO;
-    if (self.navigationController.viewControllers.count == 1) {
+    if (self.presentingViewController && (self.modalPresentationStyle == UIModalPresentationFullScreen || self.modalPresentationStyle == UIModalPresentationOverCurrentContext) && self.navigationController.viewControllers.count == 1) {
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:[self localizedStringForKey:@"done" withDefault:@"Done"] style:UIBarButtonItemStyleDone target:self action:@selector(done:)];
         self.navigationItem.rightBarButtonItem = doneButton;
         if (!_sharingDisabled) {

--- a/FSImageViewer/FSImageViewerViewController.m
+++ b/FSImageViewer/FSImageViewerViewController.m
@@ -128,7 +128,7 @@
 
     shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(share:)];
     shareButton.enabled = NO;
-    if (!self.shouldNotShowModally || (self.presentingViewController && (self.modalPresentationStyle == UIModalPresentationFullScreen))) {
+    if (!self.shouldNotShowModally && (self.presentingViewController && (self.modalPresentationStyle == UIModalPresentationFullScreen))) {
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:[self localizedStringForKey:@"done" withDefault:@"Done"] style:UIBarButtonItemStyleDone target:self action:@selector(done:)];
         self.navigationItem.rightBarButtonItem = doneButton;
         if (!_sharingDisabled) {


### PR DESCRIPTION
Trying to push this view controller onto a navigation stack that's already being presented causes a 'Done' button. This new method only puts on a done button if the FSImageViewerViewController is the only view controller in the navigation stack.
